### PR TITLE
Fix bug

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -16,6 +16,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.CanHelpWithTaskPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.task.DeadlineComparator;
 import seedu.address.model.task.DefaultComparator;
 import seedu.address.model.task.Task;
 
@@ -232,10 +233,11 @@ public class ModelManager implements Model {
     @Override
     public void updateSortedTaskList(Comparator<Task> comparator) {
         requireNonNull(comparator);
+        assert comparator instanceof DefaultComparator || comparator instanceof DeadlineComparator;
         if (comparator instanceof DefaultComparator) {
             sortedTasks.setComparator(new DefaultComparator(taskList));
         } else {
-            sortedTasks.setComparator(comparator);
+            sortedTasks.setComparator(new DeadlineComparator(taskList));
         }
     }
 

--- a/src/main/java/seedu/address/model/task/DeadlineComparator.java
+++ b/src/main/java/seedu/address/model/task/DeadlineComparator.java
@@ -1,6 +1,10 @@
 package seedu.address.model.task;
 
+import static java.util.Objects.requireNonNull;
+
 import java.util.Comparator;
+
+import seedu.address.model.TaskList;
 
 /**
  * Compares two tasks on the basis of the task with an earlier deadline ordered in front of the other task.
@@ -9,6 +13,25 @@ public class DeadlineComparator implements Comparator<Task> {
 
     private static final String COMPARE_CRITERIA = "in order of task with earliest deadline.";
 
+    private TaskList taskList;
+
+    /**
+     * Constructs a {@code DefaultComparator} with the given tasklist.
+     *
+     * @param taskList A valid TaskList.
+     */
+    public DeadlineComparator(TaskList taskList) {
+        requireNonNull(taskList);
+        this.taskList = taskList;
+    }
+
+    /**
+     * Constructs a DefaultComparator with an empty tasklist.
+     */
+    public DeadlineComparator() {
+        this.taskList = new TaskList();
+    }
+
     @Override
     public int compare(Task a, Task b) {
         if (a.getDeadline().deadline.isBefore(b.getDeadline().deadline)) {
@@ -16,7 +39,7 @@ public class DeadlineComparator implements Comparator<Task> {
         } else if (a.getDeadline().deadline.isAfter(b.getDeadline().deadline)) {
             return 1;
         }
-        return 0;
+        return new DefaultComparator(taskList).compare(a, b);
     }
 
     @Override
@@ -24,7 +47,8 @@ public class DeadlineComparator implements Comparator<Task> {
         if (other == this) { // short circuit if same object
             return true;
         } else if (other instanceof DeadlineComparator) { // instanceof handles nulls
-            return true;
+            DeadlineComparator otherDeadlineComparator = (DeadlineComparator) other;
+            return this.taskList.equals(otherDeadlineComparator.taskList); // state check
         }
         return false;
     }

--- a/src/test/java/seedu/address/model/task/DeadlineComparatorTest.java
+++ b/src/test/java/seedu/address/model/task/DeadlineComparatorTest.java
@@ -4,24 +4,45 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.TypicalTasks.FINISH_TP;
-import static seedu.address.testutil.TypicalTasks.LAB_2;
+import static seedu.address.testutil.TypicalTasks.getTypicalTaskList;
 
 import java.util.Comparator;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import seedu.address.model.module.Module;
+import seedu.address.model.TaskList;
 
 public class DeadlineComparatorTest {
 
+    private TaskList firstTaskList;
+    private TaskList secondTaskList;
+    private DeadlineComparator firstDeadlineComparator;
+    private DeadlineComparator secondDeadlineComparator;
+
+    @BeforeEach
+    public void setUp() {
+        firstTaskList = getTypicalTaskList();
+        secondTaskList = new TaskList();
+        secondTaskList.addTask(FINISH_TP);
+        Task finishTpCopy = new Task(
+                new TaskName("Finish TP 1"), FINISH_TP.getModule(), FINISH_TP.getDeadline(), FINISH_TP.getStatus());
+        secondTaskList.addTask(finishTpCopy);
+        firstDeadlineComparator = new DeadlineComparator(firstTaskList);
+        secondDeadlineComparator = new DeadlineComparator(secondTaskList);
+    }
+
     @Test
     public void equals() {
-        DeadlineComparator firstDeadlineComparator = new DeadlineComparator();
-        DeadlineComparator secondDeadlineComparator = new DeadlineComparator();
-
         // same object -> returns true
         assertTrue(firstDeadlineComparator.equals(firstDeadlineComparator));
-        assertTrue(firstDeadlineComparator.equals(secondDeadlineComparator));
+
+        // same values -> returns true
+        DeadlineComparator firstDeadlineComparatorCopy = new DeadlineComparator(firstTaskList);
+        assertTrue(firstDeadlineComparator.equals(firstDeadlineComparatorCopy));
+
+        // different comparator -> returns false
+        assertFalse(firstDeadlineComparator.equals(secondDeadlineComparator));
 
         // different types -> returns false
         assertFalse(firstDeadlineComparator.equals(1));
@@ -34,10 +55,13 @@ public class DeadlineComparatorTest {
     @Test
     public void compare() {
         Comparator<Task> comparator = new DeadlineComparator();
-        assertEquals(1, comparator.compare(FINISH_TP, LAB_2));
-        assertEquals(-1, comparator.compare(LAB_2, FINISH_TP));
-        assertEquals(0, comparator.compare(LAB_2, LAB_2));
-        assertEquals(0, comparator.compare(LAB_2, new Task(new TaskName("Tutorial 2"), new Module("MA2001"),
-                LAB_2.getDeadline(), new Status(true))));
+        assertEquals(-1, firstDeadlineComparator.compare(
+                firstTaskList.getTaskList().get(0), firstTaskList.getTaskList().get(1)));
+        assertEquals(1, firstDeadlineComparator.compare(
+                firstTaskList.getTaskList().get(1), firstTaskList.getTaskList().get(0)));
+        assertEquals(-1, secondDeadlineComparator.compare(
+                secondTaskList.getTaskList().get(1), secondTaskList.getTaskList().get(0)));
+        assertEquals(1, secondDeadlineComparator.compare(
+                secondTaskList.getTaskList().get(0), secondTaskList.getTaskList().get(1)));
     }
 }


### PR DESCRIPTION
There is a bug that while on list time view, marking/unmarking tasks while there are multiple tasks with same deadline causes marked task to jump to the top of the cluster of tasks with same deadline when it was not at first. Fixed this by comparing with default comparator when deadline comparator returns 0 for two tasks of same deadline.